### PR TITLE
Use environment variable for Pico SDK path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 # initalize pico_sdk from installed location
 # (note this can come from environment, CMake cache etc)
-set(PICO_SDK_PATH "p:/pico/pico-sdk")
+set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)


### PR DESCRIPTION
This replaces the hardcoded path with the "PICO_SDK_PATH" environment variable.