### PR TITLE
Added qmtech rp2040 daughterboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ An additional feature provides a bridge to an external UART.  This is often usef
 
 Other configurations and RP2040 boards are supported.  
 
-Select the board you want to use, or define a new one.
+In `dirtyJtagConfig.h`, select the board you want to use, or define a new one.
 
 ``` C
 #define BOARD_TYPE BOARD_PICO
 //#define BOARD_TYPE BOARD_ADAFRUIT_ITSY
 //#define BOARD_TYPE BOARD_SPOKE_RP2040
+//#define BOARD_TYPE BOARD_QMTECH_RP2040_DAUGHTERBOARD
 ```
 
 The following values control where the code expects to find functionality.  Of course, not all pins can can be used for all functions.  Take care, especially with the UART pins, to ensure compatibility.

--- a/dirtyJtag.c
+++ b/dirtyJtag.c
@@ -18,7 +18,9 @@
 void init_pins()
 {
     bi_decl(bi_4pins_with_names(PIN_TCK, "TCK", PIN_TDI, "TDI", PIN_TDO, "TDO", PIN_TMS, "TMS"));
+    #if !( BOARD_TYPE == BOARD_QMTECH_RP2040_DAUGHTERBOARD )
     bi_decl(bi_2pins_with_names(PIN_RST, "RST", PIN_TRST, "TRST"));
+    #endif
 }
 
 pio_jtag_inst_t jtag = {
@@ -29,7 +31,11 @@ pio_jtag_inst_t jtag = {
 void djtag_init()
 {
     init_pins();
+    #if !( BOARD_TYPE == BOARD_QMTECH_RP2040_DAUGHTERBOARD )
     init_jtag(&jtag, 1000, PIN_TCK, PIN_TDI, PIN_TDO, PIN_TMS, PIN_RST, PIN_TRST);
+    #else
+    init_jtag(&jtag, 1000, PIN_TCK, PIN_TDI, PIN_TDO, PIN_TMS, 255, 255);
+    #endif
 }
 typedef uint8_t cmd_buffer[64];
 static uint wr_buffer_number = 0;

--- a/dirtyJtagConfig.h
+++ b/dirtyJtagConfig.h
@@ -4,14 +4,16 @@
 // Set to 0 to disable USB-CDC-UART bridge
 #define USB_CDC_UART_BRIDGE  1
 
-#define BOARD_PICO           0
-#define BOARD_ADAFRUIT_ITSY  1
-#define BOARD_SPOKE_RP2040   2
+#define BOARD_PICO                        0
+#define BOARD_ADAFRUIT_ITSY               1
+#define BOARD_SPOKE_RP2040                2
+#define BOARD_QMTECH_RP2040_DAUGHTERBOARD 3
 
 // Select the board type from the above
 #define BOARD_TYPE BOARD_PICO
 //#define BOARD_TYPE BOARD_ADAFRUIT_ITSY
 //#define BOARD_TYPE BOARD_SPOKE_RP2040
+//#define BOARD_TYPE BOARD_QMTECH_RP2040_DAUGHTERBOARD
 
 // General mapping
 // TDI  SPIO RX
@@ -81,6 +83,28 @@
 #define PIN_UART_TX    28
 #define PIN_UART_RX    29
 #endif // USB_CDC_UART_BRIDGE
+
+#elif ( BOARD_TYPE == BOARD_QMTECH_RP2040_DAUGHTERBOARD )
+
+// in rp2040 daughterboard UART pins are connected to FPGA pins
+// depending on the FPGA pin configuration there is a possibility
+// of damage so these pins are not going to be setup
+#define USB_CDC_UART_BRIDGE  0
+
+#define PIN_TDI  16 
+#define PIN_TDO  17
+#define PIN_TCK  18
+#define PIN_TMS  19
+// in rp2040 daughterboard these pins are connected to FPGA pins
+// depending on the FPGA pin configuration there is a possibility
+// of damage so these pins are not going to be setup
+// #define PIN_RST  X
+// #define PIN_TRST X
+
+#define LED_INVERTED   0
+#define PIN_LED_TX     25
+#define PIN_LED_ERROR  25
+#define PIN_LED_RX     25
 
 #endif // BOARD_TYPE
 

--- a/pio_jtag.c
+++ b/pio_jtag.c
@@ -241,12 +241,18 @@ uint8_t __time_critical_func(pio_jtag_write_tms_blocking)(const pio_jtag_inst_t 
 
 static void init_pins(uint pin_tck, uint pin_tdi, uint pin_tdo, uint pin_tms, uint pin_rst, uint pin_trst)
 {
+    #if !( BOARD_TYPE == BOARD_QMTECH_RP2040_DAUGHTERBOARD )
     // emulate open drain with pull up and direction
     gpio_pull_up(pin_rst);
     gpio_clr_mask((1u << pin_tms) | (1u << pin_rst) | (1u << pin_trst));
     gpio_init_mask((1u << pin_tms) | (1u << pin_rst) | (1u << pin_trst));
     gpio_set_dir_masked( (1u << pin_tms) | (1u << pin_trst), 0xffffffffu);
     gpio_set_dir(pin_rst, false);
+    #else
+    gpio_clr_mask((1u << pin_tms));
+    gpio_init_mask((1u << pin_tms));
+    gpio_set_dir_masked( (1u << pin_tms), 0xffffffffu);
+    #endif
 }
 
 void init_jtag(pio_jtag_inst_t* jtag, uint freq, uint pin_tck, uint pin_tdi, uint pin_tdo, uint pin_tms, uint pin_rst, uint pin_trst)
@@ -256,8 +262,10 @@ void init_jtag(pio_jtag_inst_t* jtag, uint freq, uint pin_tck, uint pin_tdi, uin
     jtag->pin_tdo = pin_tdo;
     jtag->pin_tck = pin_tck;
     jtag->pin_tms = pin_tms;
+    #if !( BOARD_TYPE == BOARD_QMTECH_RP2040_DAUGHTERBOARD )
     jtag->pin_rst = pin_rst;
     jtag->pin_trst = pin_trst;
+    #endif
     uint16_t clkdiv = 31;  // around 1 MHz @ 125MHz clk_sys
     pio_jtag_init(jtag->pio, jtag->sm,
                     clkdiv,


### PR DESCRIPTION
I have to make a few modifications about pin management since there is no RST neither TRST pins the for QMTECH rp2040 daughterboard, depending on the core FPGA pin configuration the default pin assingment can damage the FPGA pins.

Tested with my rp2040 and its reliable.