### PR TITLE
Set USB_BCD to USB 2.0 for all boards

### DIFF
--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -27,12 +27,6 @@
 #include "tusb.h"
 #include "get_serial.h"
 
-#if ( CDC_UART_INTF_COUNT > 0 )
-#define USB_BCD   0x0200
-#else
-#define USB_BCD   0x0110
-#endif
-
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
@@ -40,7 +34,7 @@ tusb_desc_device_t const desc_device =
 {
     .bLength            = sizeof(tusb_desc_device_t),
     .bDescriptorType    = TUSB_DESC_DEVICE,
-    .bcdUSB             = USB_BCD,
+    .bcdUSB             = 0x0200,
     .bDeviceClass       = 0x00, // Each interface specifies its own
     .bDeviceSubClass    = 0x00, // Each interface specifies its own
     .bDeviceProtocol    = 0x00,


### PR DESCRIPTION
Hello!

The goal of this PR is to remove redundant and ambiguous code.
AFAIK the boards that are supported by this project all have USB 2.0 compatible controllers.

BOARD_ADAFRUIT_ITSY
Multiple boards, don't know which one is supported.
ItsyBitsy 32u4 has an ATmega32u4 chip.
[Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf) shows USB 2.0 support.

BOARD_WERKZEUG
The word Wekzeug means tool in German.
I could not find a board like that...

BOARD_SPOKE_RP2040
BOARD_QMTECH_RP2040_DAUGHTERBOARD
These have rp2040, which has USB 2.0 support in device mode.
(dJ uses device mode.)

BOARD_RP2040_ZERO
Not sure about this.
[The zero has a BCM2835.](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#zero-series)
[Datasheet](https://datasheets.raspberrypi.com/bcm2835/bcm2835-peripherals.pdf) is somewhat unclear, but it seems to have a USB 2.0 block.

I only have a Pico2 board and I have tested this change with CDC_UART_INTF_COUNT set to 2 and 0.
No difference in loading a test.bit file to an FPGA with openFPGALoader.

Please test, if you have the above boards.

Thanks.

See issue #39 .